### PR TITLE
Add metadata version openstack/2015-10-15 (Liberty)

### DIFF
--- a/playbooks/roles/bifrost-configdrives-dynamic/tasks/main.yml
+++ b/playbooks/roles/bifrost-configdrives-dynamic/tasks/main.yml
@@ -25,25 +25,17 @@
   command: mktemp -d
   register: variable_configdrive_location
 
-- name: "Make metadata folder - /openstack/{{ metadata_version }}"
+- name: "Make metadata folders - /openstack/<version>"
   file:
     state: directory
-    name: "{{ variable_configdrive_location.stdout }}/{{ uuid }}/openstack/{{ metadata_version }}/"
+    name: "{{ variable_configdrive_location.stdout }}/{{ uuid }}/openstack/{{ item }}/"
+  with_items: "{{ metadata_versions }}"
 
-- name: "Make metadata folder - /openstack/latest"
-  file:
-    state: directory
-    name: "{{ variable_configdrive_location.stdout }}/{{ uuid }}/openstack/latest/"
-
-- name: "Place template in each openstack/{{ metadata_version }} folder"
+- name: "Place template in each openstack/<version> folder"
   template:
     src: openstack_meta_data.json.j2
-    dest: "{{ variable_configdrive_location.stdout }}/{{ uuid }}/openstack/{{ metadata_version }}/meta_data.json"
-
-- name: "Place template in each openstack/latest folder"
-  template:
-    src: openstack_meta_data.json.j2
-    dest: "{{ variable_configdrive_location.stdout }}/{{ uuid }}/openstack/latest/meta_data.json"
+    dest: "{{ variable_configdrive_location.stdout }}/{{ uuid }}/openstack/{{ item }}/meta_data.json"
+  with_items: "{{ metadata_versions }}"
 
 - name: "Generate network_data"
   network_metadata:
@@ -58,23 +50,29 @@
     node_network_data: "{{ node_network_data | default(node_network_info) }}"
   when: addressing_mode is undefined or "dhcp" not in addressing_mode
 
-- name: "Place network data template in each openstack/latest folder"
+- name: "Place network data template in each openstack/<version> folder"
   template:
     src: network_data.json.j2
-    dest: "{{ variable_configdrive_location.stdout }}/{{ uuid }}/openstack/latest/network_data.json"
-  when: addressing_mode is undefined or "dhcp" not in addressing_mode
+    dest: "{{ variable_configdrive_location.stdout }}/{{ uuid }}/openstack/{{ item }}/network_data.json"
+  with_items: "{{ metadata_versions }}"
+  when:
+    - item in metadata_versions_supporting_network_data
+    - addressing_mode is undefined or "dhcp" not in addressing_mode
 
 # TODO(TheJulia): Deprecation removal of the old network_info file name
 # should likely take place after an elongated deprecation cycle.
 # Begin deprecated in the Ocata release suggests Queens as the point
 # in which we should remove it.
-- name: "Place deprecated network info file location in each openstack/latest folder"
+- name: "Place deprecated network info file location in each openstack/<version> folder"
   template:
     src: network_data.json.j2
-    dest: "{{ variable_configdrive_location.stdout }}/{{ uuid }}/openstack/latest/network_info.json"
-  when: addressing_mode is undefined or "dhcp" not in addressing_mode
+    dest: "{{ variable_configdrive_location.stdout }}/{{ uuid }}/openstack/{{ item }}/network_info.json"
+  with_items: "{{ metadata_versions }}"
+  when:
+    - item in metadata_versions_supporting_network_data
+    - addressing_mode is undefined or "dhcp" not in addressing_mode
 
-- name: "Make metadata folder - /openstack/latest"
+- name: "Make metadata folder - /openstack/content"
   file:
     state: directory
     name: "{{ variable_configdrive_location.stdout }}/{{ uuid }}/openstack/content/"

--- a/playbooks/roles/bifrost-configdrives-dynamic/vars/main.yml
+++ b/playbooks/roles/bifrost-configdrives-dynamic/vars/main.yml
@@ -1,2 +1,9 @@
 ---
-metadata_version: "2012-08-10"
+metadata_versions:
+  - "2012-08-10"
+  - "2015-10-15"
+  - "latest"
+
+metadata_versions_supporting_network_data:
+  - "2015-10-15"
+  - "latest"


### PR DESCRIPTION
This version introduced the network_data.json file, and is supported by
cloud-init 0.7.9. Cloud-init 0.7.9 will always prefer a versioned metadata to
'latest', which in this case forces the use of the 2012-08-10 Folsom version,
which does not provide network_data.json.