### PR TITLE
Port queens uefi patches to rocky

### DIFF
--- a/playbooks/roles/bifrost-create-dib-image/vars/main.yml
+++ b/playbooks/roles/bifrost-create-dib-image/vars/main.yml
@@ -13,5 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 dib_host_required_packages:
+  - dosfstools
   - e2fsprogs
+  - gdisk
   - xfsprogs

--- a/playbooks/roles/bifrost-ironic-install/defaults/main.yml
+++ b/playbooks/roles/bifrost-ironic-install/defaults/main.yml
@@ -67,7 +67,8 @@ cirros_deploy_image_upstream_url: https://download.cirros-cloud.net/0.3.4/cirros
 # this setting, and perform manual configuration of your DHCP server.
 include_dhcp_server: true
 # *_git_url can be overridden by local clones for offline installs
-dib_git_url: https://opendev.org/openstack/diskimage-builder
+dib_git_url: https://github.com/stackhpc/diskimage-builder
+dib_git_branch: secureboot
 ironicclient_git_url: https://opendev.org/openstack/python-ironicclient
 shade_git_url: https://opendev.org/openstack/shade
 ironic_git_url: https://opendev.org/openstack/ironic

--- a/playbooks/roles/bifrost-ironic-install/defaults/main.yml
+++ b/playbooks/roles/bifrost-ironic-install/defaults/main.yml
@@ -44,6 +44,9 @@ ans_network_interface: "{{ network_interface | replace('-', '_') }}"
 # documentation at https://ipxe.org/crypto
 ipa_file_protocol: "http"
 
+enable_uefi_ipxe: true
+ipxe_efi_binary: ipxe.efi
+
 ipa_upstream_release: "stable-rocky"
 ipa_kernel: "{{http_boot_folder}}/ipa.vmlinuz"
 ipa_ramdisk: "{{http_boot_folder}}/ipa.initramfs"

--- a/playbooks/roles/bifrost-ironic-install/tasks/create_tftpboot.yml
+++ b/playbooks/roles/bifrost-ironic-install/tasks/create_tftpboot.yml
@@ -52,6 +52,31 @@
 - name: "Copy full iPXE image into /tftpboot"
   copy: src={{ ipxe_dir }}/{{ ipxe_full_binary }} dest=/tftpboot/ remote_src=true
 
+- name: "Set up iPXE for EFI booting"
+  block:
+    - name: "Check if the iPXE EFI image is present"
+      stat:
+        path: "{{ ipxe_dir }}/{{ ipxe_efi_binary }}"
+        get_md5: false
+      register: test_ipxe_efi_binary_path
+      ignore_errors: true
+
+    - name: "Abort if iPXE EFI image is missing"
+      fail:
+        msg: >
+          Aborting installation: The {{ ipxe_efi_binary }} image was not found
+          at the {{ ipxe_dir }} location.  Please place this file or consider
+          re-running with download_ipxe set to a value of true.
+      when:
+        - test_ipxe_efi_binary_path.stat.exists | bool == false
+
+    - name: "Copy iPXE EFI image into {{ http_boot_folder }}/"
+      copy: src={{ ipxe_dir }}/{{ ipxe_efi_binary }} dest={{ http_boot_folder }}/ remote_src=true
+
+    - name: "Copy iPXE EFI image into /tftpboot"
+      copy: src={{ ipxe_dir }}/{{ ipxe_efi_binary }} dest=/tftpboot/ remote_src=true
+  when: enable_uefi_ipxe | bool == true
+
 # Similar logic to below can be utilized to retrieve files
 - name: "Determine if folder exists, else create and populate folder."
   stat: path="{{ ironic_tftp_master_path }}"

--- a/playbooks/roles/bifrost-ironic-install/tasks/get_ipxe.yml
+++ b/playbooks/roles/bifrost-ironic-install/tasks/get_ipxe.yml
@@ -21,7 +21,7 @@
     group=root
     mode=0755
 
-- name: Get ipxe files
+- name: Get iPXE files
   get_url:
     url: "https://boot.ipxe.org/{{ item }}"
     dest: "{{ ipxe_dir }}/{{ item }}"
@@ -33,3 +33,16 @@
   with_items:
     - undionly.kpxe
     - ipxe.pxe
+
+- name: Get iPXE EFI binary
+  get_url:
+    url: "https://boot.ipxe.org/{{ item }}"
+    dest: "{{ ipxe_dir }}/{{ item }}"
+    force: yes
+  register: ipxe_efi_binary_download_done
+  until: ipxe_efi_binary_download_done|succeeded
+  retries: 5
+  delay: 10
+  with_items:
+    - "{{ ipxe_efi_binary }}"
+  when: enable_uefi_ipxe | bool == true

--- a/playbooks/roles/bifrost-ironic-install/templates/dnsmasq.conf.j2
+++ b/playbooks/roles/bifrost-ironic-install/templates/dnsmasq.conf.j2
@@ -94,6 +94,14 @@ dhcp-userclass=set:gpxe,"gPXE"
 dhcp-boot=tag:gpxe,/ipxe.pxe
 
 dhcp-match=set:ipxe,175 # iPXE sends a 175 option.
+{% if enable_uefi_ipxe | bool == true %}
+dhcp-match=set:efi,option:client-arch,7
+dhcp-match=set:efi,option:client-arch,9
+dhcp-match=set:efi,option:client-arch,11
+# Client is PXE booting over EFI without iPXE ROM; send EFI version of iPXE chainloader
+dhcp-boot=tag:efi,tag:!ipxe,/{{ ipxe_efi_binary }}
+{% endif %}
+
 {% if testing | bool == true %}
 dhcp-boot=tag:ipxe,http://192.168.122.1:{{ file_url_port }}/boot.ipxe
 {% else %}

--- a/playbooks/roles/bifrost-ironic-install/templates/inspector-default-boot-ipxe.j2
+++ b/playbooks/roles/bifrost-ironic-install/templates/inspector-default-boot-ipxe.j2
@@ -5,6 +5,6 @@ dhcp || reboot
 goto introspect
 
 :introspect
-kernel {{ ipa_kernel_url }} ipa-inspection-callback-url=http://{{ hostvars[inventory_hostname]['ansible_' + ans_network_interface ]['ipv4']['address'] }}:5050/v1/continue systemd.journald.forward_to_console=yes BOOTIF=${mac} nofb nomodeset vga=normal console=ttyS0 {{ inspector_extra_kernel_options | default('') }} initrd=ipa.initramfs
+kernel {{ ipa_kernel_url }} ipa-inspection-callback-url=http://{{ hostvars[inventory_hostname]['ansible_' + ans_network_interface ]['ipv4']['address'] }}:5050/v1/continue systemd.journald.forward_to_console=yes BOOTIF=${mac} nofb nomodeset vga=normal console=ttyS0 {{ inspector_extra_kernel_options | default('') }} initrd={{ ipa_ramdisk_url | basename }}
 initrd {{ ipa_ramdisk_url }}
 boot

--- a/playbooks/roles/bifrost-ironic-install/templates/ironic-inspector.conf.j2
+++ b/playbooks/roles/bifrost-ironic-install/templates/ironic-inspector.conf.j2
@@ -80,3 +80,6 @@ enroll_node_driver = {{ inspector.discovery.default_node_driver }}
 auth_type = none
 endpoint = {{ inspector_store_data_url }}
 {% endif %}
+
+[capabilities]
+boot_mode = True

--- a/playbooks/roles/bifrost-ironic-install/templates/ironic.conf.j2
+++ b/playbooks/roles/bifrost-ironic-install/templates/ironic.conf.j2
@@ -38,6 +38,10 @@ pxe_bootfile_name = undionly.kpxe
 ipxe_enabled = true
 ipxe_boot_script = /etc/ironic/boot.ipxe
 tftp_master_path = {{ ironic_tftp_master_path }}
+{% if enable_uefi_ipxe | bool %}
+uefi_pxe_bootfile_name = {{ ipxe_efi_binary }}
+uefi_pxe_config_template = $pybasedir/drivers/modules/ipxe_config.template
+{% endif %}
 
 [deploy]
 http_url = http://{{ hostvars[inventory_hostname]['ansible_' + ans_network_interface]['ipv4']['address'] }}:{{ file_url_port }}/

--- a/playbooks/roles/bifrost-ironic-install/templates/ironic.conf.j2
+++ b/playbooks/roles/bifrost-ironic-install/templates/ironic.conf.j2
@@ -42,6 +42,7 @@ tftp_master_path = {{ ironic_tftp_master_path }}
 [deploy]
 http_url = http://{{ hostvars[inventory_hostname]['ansible_' + ans_network_interface]['ipv4']['address'] }}:{{ file_url_port }}/
 http_root = {{ http_boot_folder }}
+default_boot_option = local
 
 [conductor]
 clean_nodes = {{ cleaning | lower }}

--- a/playbooks/roles/bifrost-prep-for-install/defaults/main.yml
+++ b/playbooks/roles/bifrost-prep-for-install/defaults/main.yml
@@ -2,7 +2,7 @@
 # git_root is the folder where to place downloaded git repos
 git_root: "/opt/stack"
 # *_git_url can be overridden by local clones for offline installs
-dib_git_url: https://opendev.org/openstack/diskimage-builder
+dib_git_url: https://github.com/stackhpc/diskimage-builder
 ironicclient_git_url: https://opendev.org/openstack/python-ironicclient
 shade_git_url: https://opendev.org/openstack/shade
 ironic_git_url: https://opendev.org/openstack/ironic
@@ -28,7 +28,7 @@ ipa_git_folder: "{{ git_root }}/ironic-python-agent"
 ironicclient_git_branch: stable/rocky
 ironic_git_branch: stable/rocky
 shade_git_branch: stable/rocky
-dib_git_branch: 2.38.0
+dib_git_branch: secureboot
 ironicinspector_git_branch: stable/rocky
 ironicinspectorclient_git_branch: stable/rocky
 reqs_git_branch: stable/rocky


### PR DESCRIPTION
Notes on cherry-picks from uefi/queens
---------------------------------------

cc5b990d Configure ironic-inspector to set boot_mode capability (conflict)
49f2a61d Allow to customize [ipmi]/command_retry_timeout
76ca6aca Set default_boot_option for bifrost
b87c0a60 Get ramdisk name from variable instead of hardcoding it (conflict)
2955eb79 Use our fork of diskimage-builder (conflict)
f06c32ab Install packages providing sgdisk and mkfs.vfat (conflict)
3352935e Download snponly.efi (replaced with [1])
9f67f7ae Add default configuration for UEFI booting (replaced with [1])
1a57256f Adapt to newer code (replaced with [1])
e66ef17c Initial support for EFI booting (replaced with [1])

[1] https://review.opendev.org/#/c/268808/6


Upgrade note
------------

- Set ipxe_efi_binary to snponly.efi (bifrost globals.yml)