### PR TITLE
Port rocky patches to stein (secureboot support)

### DIFF
--- a/playbooks/roles/bifrost-ironic-install/defaults/main.yml
+++ b/playbooks/roles/bifrost-ironic-install/defaults/main.yml
@@ -72,7 +72,8 @@ cirros_deploy_image_upstream_url: https://download.cirros-cloud.net/0.3.4/cirros
 # this setting, and perform manual configuration of your DHCP server.
 include_dhcp_server: true
 # *_git_url can be overridden by local clones for offline installs
-dib_git_url: https://opendev.org/openstack/diskimage-builder
+dib_git_url: https://github.com/stackhpc/diskimage-builder
+dib_git_branch: secureboot
 ironicclient_git_url: https://opendev.org/openstack/python-ironicclient
 openstacksdk_git_url: https://opendev.org/openstack/openstacksdk
 shade_git_url: https://opendev.org/openstack/shade

--- a/playbooks/roles/bifrost-ironic-install/templates/ironic-inspector.conf.j2
+++ b/playbooks/roles/bifrost-ironic-install/templates/ironic-inspector.conf.j2
@@ -82,3 +82,6 @@ enroll_node_driver = {{ inspector.discovery.default_node_driver }}
 auth_type = none
 endpoint = {{ inspector_store_data_url }}
 {% endif %}
+
+[capabilities]
+boot_mode = True

--- a/playbooks/roles/bifrost-prep-for-install/defaults/main.yml
+++ b/playbooks/roles/bifrost-prep-for-install/defaults/main.yml
@@ -2,7 +2,7 @@
 # git_root is the folder where to place downloaded git repos
 git_root: "/opt/stack"
 # *_git_url can be overridden by local clones for offline installs
-dib_git_url: https://opendev.org/openstack/diskimage-builder
+dib_git_url: https://github.com/stackhpc/diskimage-builder
 ironicclient_git_url: https://opendev.org/openstack/python-ironicclient
 openstacksdk_git_url: https://opendev.org/openstack/openstacksdk
 shade_git_url: https://opendev.org/openstack/shade
@@ -31,7 +31,7 @@ ironicclient_git_branch: stable/stein
 ironic_git_branch: stable/stein
 openstacksdk_git_branch: stable/stein
 shade_git_branch: stable/stein
-dib_git_branch: 2.38.0
+dib_git_branch: secureboot
 ironicinspector_git_branch: stable/stein
 ironicinspectorclient_git_branch: stable/stein
 reqs_git_branch: stable/stein


### PR DESCRIPTION
Original list of patches:

c27a3384 Configure ironic-inspector to set boot_mode capability
e7dc60de Set default_boot_option for bifrost
afb09d82 Get ramdisk name from variable instead of hardcoding it
a891d281 Use our fork of diskimage-builder
fd82f0c7 Install packages providing sgdisk and mkfs.vfat
d21b480f Add initial support for EFI booting

Filtered for patches that are now upstream, leaves:

a891d281 Use our fork of diskimage-builder
c27a3384 Configure ironic-inspector to set boot_mode capability
