### PR TITLE
Wallaby backports

### DIFF
--- a/playbooks/roles/bifrost-ironic-install/README.md
+++ b/playbooks/roles/bifrost-ironic-install/README.md
@@ -74,6 +74,10 @@ If you chose to utilize the dhcp server, You may wish to set default ranges:
 dhcp_pool_start: 192.168.1.200
 dhcp_pool_end: 192.168.1.250
 
+If you want to use bifrost as a dhcp relay target, please set ``dhcp_pool_mask``:
+
+dhcp_pool_mask: 255.255.255.0
+
 And also set the default dhcp address lease time:
 
 dhcp_lease_time: 12h

--- a/playbooks/roles/bifrost-ironic-install/defaults/main.yml
+++ b/playbooks/roles/bifrost-ironic-install/defaults/main.yml
@@ -148,6 +148,7 @@ enabled_bios_interfaces: ""
 enabled_boot_interfaces: ""
 enabled_management_interfaces: ""
 enabled_power_interfaces: ""
+enabled_vendor_interfaces: ""
 
 default_resource_class: baremetal
 

--- a/playbooks/roles/bifrost-ironic-install/defaults/main.yml
+++ b/playbooks/roles/bifrost-ironic-install/defaults/main.yml
@@ -148,6 +148,7 @@ enabled_bios_interfaces: ""
 enabled_boot_interfaces: ""
 enabled_management_interfaces: ""
 enabled_power_interfaces: ""
+enabled_raid_interfaces: ""
 enabled_vendor_interfaces: ""
 
 default_resource_class: baremetal

--- a/playbooks/roles/bifrost-ironic-install/tasks/hw_types.yml
+++ b/playbooks/roles/bifrost-ironic-install/tasks/hw_types.yml
@@ -59,3 +59,13 @@
       {%- if enable_credential_less_deploy|bool -%},agent{%- endif -%}
       {%- if "staging-wol" in enabled_hardware_types -%},staging-wol{%- endif -%}
   when: not enabled_power_interfaces
+
+- name: "Configure vendor interfaces if required"
+  set_fact:
+    enabled_vendor_interfaces: >-
+      no-vendor
+      {%- if "idrac" in enabled_hardware_types -%},idrac-redfish{%- endif -%}
+      {%- if "ilo" in enabled_hardware_types -%},ilo{%- endif -%}
+      {%- if "ipmi" in enabled_hardware_types -%},ipmitool{%- endif -%}
+      {%- if "redfish" in enabled_hardware_types -%},redfish{%- endif -%}
+  when: not enabled_vendor_interfaces

--- a/playbooks/roles/bifrost-ironic-install/tasks/hw_types.yml
+++ b/playbooks/roles/bifrost-ironic-install/tasks/hw_types.yml
@@ -60,6 +60,15 @@
       {%- if "staging-wol" in enabled_hardware_types -%},staging-wol{%- endif -%}
   when: not enabled_power_interfaces
 
+- name: "Configure raid interfaces if required"
+  set_fact:
+    enabled_raid_interfaces: >-
+      no-raid,agent
+      {%- if "idrac" in enabled_hardware_types -%},idrac-redfish{%- endif -%}
+      {%- if "ilo5" in enabled_hardware_types -%},ilo5{%- endif -%}
+      {%- if "redfish" in enabled_hardware_types -%},redfish{%- endif -%}
+  when: not enabled_raid_interfaces
+
 - name: "Configure vendor interfaces if required"
   set_fact:
     enabled_vendor_interfaces: >-

--- a/playbooks/roles/bifrost-ironic-install/templates/dnsmasq.conf.j2
+++ b/playbooks/roles/bifrost-ironic-install/templates/dnsmasq.conf.j2
@@ -66,7 +66,7 @@ dhcp-range=192.168.122.2,192.168.122.254,12h
 {% elif inventory_dhcp | bool == true %}
 dhcp-range={{dhcp_pool_start}},static,{{dhcp_static_mask}},{{dhcp_lease_time}}
 {% else %}
-dhcp-range={{dhcp_pool_start}},{{dhcp_pool_end}},{{dhcp_lease_time}}
+dhcp-range={{dhcp_pool_start}},{{dhcp_pool_end}},{% if dhcp_pool_mask is defined %}{{dhcp_pool_mask}},{% endif %}{{dhcp_lease_time}}
 {% endif %}
 
 # Override the default route supplied by dnsmasq, which assumes the

--- a/playbooks/roles/bifrost-ironic-install/templates/ironic.conf.j2
+++ b/playbooks/roles/bifrost-ironic-install/templates/ironic.conf.j2
@@ -16,6 +16,7 @@ enabled_boot_interfaces = {{ enabled_boot_interfaces }}
 enabled_management_interfaces = {{ enabled_management_interfaces }}
 enabled_power_interfaces = {{ enabled_power_interfaces }}
 enabled_deploy_interfaces = {{ enabled_deploy_interfaces }}
+enabled_raid_interfaces = {{ enabled_raid_interfaces }}
 enabled_vendor_interfaces = {{ enabled_vendor_interfaces }}
 
 enabled_hardware_types = {{ enabled_hardware_types }}

--- a/playbooks/roles/bifrost-ironic-install/templates/ironic.conf.j2
+++ b/playbooks/roles/bifrost-ironic-install/templates/ironic.conf.j2
@@ -16,6 +16,7 @@ enabled_boot_interfaces = {{ enabled_boot_interfaces }}
 enabled_management_interfaces = {{ enabled_management_interfaces }}
 enabled_power_interfaces = {{ enabled_power_interfaces }}
 enabled_deploy_interfaces = {{ enabled_deploy_interfaces }}
+enabled_vendor_interfaces = {{ enabled_vendor_interfaces }}
 
 enabled_hardware_types = {{ enabled_hardware_types }}
 

--- a/releasenotes/notes/dhcp_pool_mask-6d9bd4d1b78be0ab.yaml
+++ b/releasenotes/notes/dhcp_pool_mask-6d9bd4d1b78be0ab.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Adds support for using dnsmasq as a DHCP relay target via the new
+    ``dhcp_pool_mask`` parameter.

--- a/releasenotes/notes/enabled_raid_interfaces-93086bc0cc29ee09.yaml
+++ b/releasenotes/notes/enabled_raid_interfaces-93086bc0cc29ee09.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Automatically configures ``enabled_raid_interfaces`` based on the
+    ``enabled_hardware_types``.
+  - |
+    Adds support for manually specified enabled raid interfaces via the new
+    ``enabled_raid_interfaces`` parameter.

--- a/releasenotes/notes/enabled_vendor_interfaces-f1b15fe75ff061fe.yaml
+++ b/releasenotes/notes/enabled_vendor_interfaces-f1b15fe75ff061fe.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Automatically configures ``enabled_vendor_interfaces`` based on the
+    ``enabled_hardware_types``.
+  - |
+    Adds support for manually specified enabled vendor interfaces via the new
+    ``enabled_vendor_interfaces`` parameter.


### PR DESCRIPTION
* Allow configuring enabled vendor interfaces (dependency for RAID interfaces) - https://review.opendev.org/c/openstack/bifrost/+/799837
* Allow configuring enabled raid interfaces - https://review.opendev.org/c/openstack/bifrost/+/806123
* Add support for being dhcp relay target - https://review.opendev.org/c/openstack/bifrost/+/804482