### PR TITLE
Backport/Xena: Add support for root filesystem UUID customisation

### DIFF
--- a/playbooks/roles/bifrost-deploy-nodes-dynamic/README.md
+++ b/playbooks/roles/bifrost-deploy-nodes-dynamic/README.md
@@ -48,13 +48,20 @@ deploy_image: This is the full path to the image to be deployed to the system.
               variable does not have a default in this role and expects to
               receive this information from the calling playbook.
 
+deploy_image_rootfs: This is the UUID of the root filesystem contained in the
+                     deployment image. It is usually not required to specify
+                     this unless software RAID based deployment is performed.
+                     See https://docs.openstack.org/ironic/latest/admin/raid.html#image-requirements
+                     for more information.
+
 instance_info: A dictionary containing the information to define an instance.
                By default, this is NOT expected to be defined, however if
                defined it is passed in whole to the deployment step.  This
-               value will override deploy_image_filename, deploy_image, and
-               network_interface variables. Key-value pairs that are generally
-               expected are image_source, image_checksum, root_gb, however,
-               any supported key/value can be submitted to the API.
+               value will override deploy_image_filename, deploy_image,
+               deploy_image_rootfs and network_interface variables. Key-value
+               pairs that are generally expected are image_source,
+               image_checksum, root_gb, however, any supported key/value can be
+               submitted to the API.
 
 inventory_dhcp: A boolean value, defaulted to false, which allows dnsmasq
                 to configure the IP of the machines, rather than putting

--- a/playbooks/roles/bifrost-deploy-nodes-dynamic/tasks/main.yml
+++ b/playbooks/roles/bifrost-deploy-nodes-dynamic/tasks/main.yml
@@ -117,6 +117,7 @@
       image_source: "{{ deploy_url_protocol }}://{{ internal_ip }}:{{ file_url_port }}/{{ deploy_image_filename }}"
       image_checksum: "{{ test_deploy_image.stat.checksum }}"
       image_disk_format: "qcow2"
+      image_rootfs_uuid: "{{ deploy_image_rootfs | default(omit) }}"
     wait: "{{ wait_for_node_deploy }}"
     timeout: " {{ wait_timeout | default(1800) }}"
   when: instance_info is not defined or ( instance_info is defined and instance_info | to_json == '{}' )

--- a/releasenotes/notes/add-support-for-rootfs-uuid-9c332327954f7580.yaml
+++ b/releasenotes/notes/add-support-for-rootfs-uuid-9c332327954f7580.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Adds support for setting root filesystem's UUID that can be deployed
+    on top of software RAID based root disk device.


### PR DESCRIPTION
As per [1], it is mandatory to specify filesystem's UUID in order to provision hosts with software RAID. This commit adds a dedicated new variable for this.

[1] https://docs.openstack.org/ironic/latest/admin/raid.html#image-requirements

Change-Id: I1ba7d400aeea473d316a44a9405d2c792b4e3054