### PR TITLE
Create /run/ironic runtime directory when service starts

### DIFF
--- a/playbooks/roles/bifrost-ironic-install/templates/systemd_template.j2
+++ b/playbooks/roles/bifrost-ironic-install/templates/systemd_template.j2
@@ -4,6 +4,9 @@ Description={{ item.service_name }} service
 [Service]
 ExecStart={{ item.service_path }}/{{ item.service_name }} {{ item.args }}
 User={{ item.username }}
+RuntimeDirectory={{ item.username }}
+RuntimeDirectoryMode=750
+RuntimeDirectoryPreserve=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
https://review.opendev.org/c/openstack/bifrost/+/827128 introduced a /run/ironic runtime directory and by default it is not persisted across reboots. Adding native systemd mechanism of managing runtime directories.

Co-Authored-By: Mark Goddard <mark@stackhpc.com>

Conflicts:
	playbooks/roles/bifrost-ironic-install/templates/systemd_template.j2

Story: 2010478
Task: 47039
Change-Id: I5946e8a864b164c019f6febe35cb70337c06fff2 (cherry picked from commit c807372f4d223e2a5aef094e095fc9dcbfc05a6e) (cherry picked from commit ae19d9b1f525e519ce471ded8e79a7e2464b3ca1)