### PR TITLE
Fix leading and trailing whitespace in inspection_callback_url

### DIFF
--- a/playbooks/roles/bifrost-ironic-install/tasks/create_tftpboot.yml
+++ b/playbooks/roles/bifrost-ironic-install/tasks/create_tftpboot.yml
@@ -184,8 +184,8 @@
     mode: "0644"
   vars:
     inspection_callback_url: >-
-      {% if enable_inspector | bool %}
+      {%- if enable_inspector | bool -%}
       {{ api_protocol }}://{{ internal_ip }}:5050/v1/continue
-      {% else %}
+      {%- else -%}
       {{ api_protocol }}://{{ internal_ip }}:6385/v1/continue_inspection
-      {% endif %}
+      {%- endif -%}

--- a/releasenotes/notes/fix-whitespace-in-inspection-callback-3f450db7ae2c91d5.yaml
+++ b/releasenotes/notes/fix-whitespace-in-inspection-callback-3f450db7ae2c91d5.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixes an issue where ``inspection_callback_url`` was templated with leading
+    whitespace. This caused the ``ipa-inspection-callback-url`` kernel command
+    line argument to be incorrectly set, leading to Ironic Python Agent posting
+    introspection data back to Ironic rather than Ironic Inspector when using
+    the ``enable_inspector`` option.


### PR DESCRIPTION
This was templating as: " https://1.2.3.4:5050/v1/continue ". We can remove this using the whitespace control modifiers from jinja, see:

https://jinja.palletsprojects.com/en/3.0.x/templates/#whitespace-control

Closes-Bug: #2072550
Change-Id: I45be2ddfb48004c9b880bd4b4627b2cf26a83616 (cherry picked from commit a9dc56f4b925493a77555b1ef2426c5a502a7c9e)