### PR TITLE
Support IPA download with authenticated requests

### DIFF
--- a/playbooks/roles/bifrost-ironic-install/defaults/main.yml
+++ b/playbooks/roles/bifrost-ironic-install/defaults/main.yml
@@ -114,6 +114,24 @@ update_repos: true
 update_ipa: "{{ update_repos }}"
 # Use the DIB dynamic-login element to insert the SSH key
 ipa_add_ssh_key: false
+
+# Username for Digest, Basic or WSSE authentication. Default is unset, in which
+# case the parameter is omitted.
+ipa_download_url_username:
+# Password for Digest, Basic or WSSE authentication. Default is unset, in which
+# case the parameter is omitted.
+ipa_download_url_password:
+# Force sending the Basic authentication header upon initial request. Useful if
+# the remote endpoint does not respond with HTTP 401 to the initial
+# unauthenticated request. Must be a boolean. Default is unset, in which case
+# the parameter is omitted.
+ipa_download_force_basic_auth:
+# List of header names that will not be sent on subsequent redirected requests.
+# Set to ['Authorization'] if being redirected from an authenticated endpoint
+# to an unauthenticated endpoint. Default is unset, in which case the parameter
+# is omitted.
+ipa_download_unredirected_headers:
+
 # NOTE(Alex-Welsh): cirros_deploy_image_upstream_url has been deprecated in
 # favor of custom_deploy_image_upstream_url but is included for backwards
 # compatibility. It should be swapped permanently to

--- a/playbooks/roles/bifrost-ironic-install/tasks/download_ipa_image.yml
+++ b/playbooks/roles/bifrost-ironic-install/tasks/download_ipa_image.yml
@@ -30,6 +30,10 @@
     owner: ironic
     group: ironic
     mode: "0644"
+    url_username: "{{ ipa_download_url_username or omit }}"
+    url_password: "{{ ipa_download_url_password or omit }}"
+    force_basic_auth: "{{ ipa_download_force_basic_auth or omit }}"
+    unredirected_headers: "{{ ipa_download_unredirected_headers or omit }}"
 
 - name: "Extract IPA kernel checksum"
   command: awk '/{{ ipa_kernel_upstream_url | basename }}|^[a-z0-9]+$/{print $1}' "{{ ipa_kernel }}.{{ ipa_kernel_upstream_checksum_algo }}"
@@ -52,6 +56,10 @@
     headers: "{{ ipa_download_headers | default(omit, true) }}"
     # Keep downloading it until we get a good copy
     force: yes
+    url_username: "{{ ipa_download_url_username or omit }}"
+    url_password: "{{ ipa_download_url_password or omit }}"
+    force_basic_auth: "{{ ipa_download_force_basic_auth or omit }}"
+    unredirected_headers: "{{ ipa_download_unredirected_headers or omit }}"
   register: ipa_kernel_download_done
   until: ipa_kernel_download_done is succeeded or
          (ipa_kernel_download_done is failed)
@@ -76,6 +84,10 @@
     owner: ironic
     group: ironic
     mode: "0644"
+    url_username: "{{ ipa_download_url_username or omit }}"
+    url_password: "{{ ipa_download_url_password or omit }}"
+    force_basic_auth: "{{ ipa_download_force_basic_auth or omit }}"
+    unredirected_headers: "{{ ipa_download_unredirected_headers or omit }}"
 
 - name: "Extract IPA ramdisk checksum"
   command: awk '/{{ ipa_ramdisk_upstream_url | basename }}|^[a-z0-9]+$/{print $1}' "{{ ipa_ramdisk }}.{{ ipa_ramdisk_upstream_checksum_algo }}"
@@ -98,6 +110,10 @@
     timeout: 300
     # Keep downloading it until we get a good copy
     force: yes
+    url_username: "{{ ipa_download_url_username or omit }}"
+    url_password: "{{ ipa_download_url_password or omit }}"
+    force_basic_auth: "{{ ipa_download_force_basic_auth or omit }}"
+    unredirected_headers: "{{ ipa_download_unredirected_headers or omit }}"
   register: ipa_ramdisk_download_done
   until: ipa_ramdisk_download_done is succeeded or
          (ipa_ramdisk_download_done is failed and ipa_ramdisk_download_done.status_code is defined and ipa_ramdisk_download_done.status_code == 404)

--- a/releasenotes/notes/ipa-download-auth-c7ae9373b08dc514.yaml
+++ b/releasenotes/notes/ipa-download-auth-c7ae9373b08dc514.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    Adds variables to configure authentication parameters in the
+    ``bifrost-ironic-install`` role, where IPA images are downloaded. The new
+    variables are ``ipa_download_url_username``, ``ipa_download_url_password``,
+    ``ipa_download_force_basic_auth`` and
+    ``ipa_download_unredirected_headers``. See documentation of the `get_url
+    <https://docs.ansible.com/ansible/latest/collections/ansible/builtin/get_url_module.html>`__
+    and `uri
+    <https://docs.ansible.com/ansible/latest/collections/ansible/builtin/uri_module.html>`__
+    Ansible modules for more details on how to use these variables.


### PR DESCRIPTION
This commit adds variables to configure authentication parameters in the bifrost-ironic-install role, where IPA images are downloaded.

The new variables are ipa_download_url_username,
ipa_download_url_password, ipa_download_force_basic_auth and ipa_download_unredirected_headers.

See Ansible documentation for more details about these variables [1,2].

[1] https://docs.ansible.com/ansible/latest/collections/ansible/builtin/get_url_module.html
[2] https://docs.ansible.com/ansible/latest/collections/ansible/builtin/uri_module.html

Change-Id: I08e098b1d8aaed0f2793bf757bc12d3ca87e03ef