### PR TITLE
Fix deployment image checksum validation

### DIFF
--- a/playbooks/roles/bifrost-ironic-install/tasks/download_deployment_image.yml
+++ b/playbooks/roles/bifrost-ironic-install/tasks/download_deployment_image.yml
@@ -73,4 +73,4 @@
           The deployment image checksum does not match the file that has been downloaded.
           Ensure that deploy_image_upstream_url, deploy_image_checksum_url, and deploy_image_checksum_algorithm are set correctly.
           To ignore the checksum, set deploy_image_checksum_algorithm to none.
-      when: deploy_image_checksum_algorithm != 'none' and downloaded_image_stat.stat.checksum != parsed_deployment_image_checksum
+      when: deploy_image_checksum_algorithm != 'none' and downloaded_image_stat.stat.checksum not in deployment_image_checksum

--- a/releasenotes/notes/fix-deploy-image-checksum-2e40b08a049bd425.yaml
+++ b/releasenotes/notes/fix-deploy-image-checksum-2e40b08a049bd425.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes an issue checksum vaidation would fail when a deployment image is
+    downloaded, even if the checksum matched. See `LP#2115188
+    <https://bugs.launchpad.net/bifrost/+bug/2115188>`__ for more details.


### PR DESCRIPTION
This change fixes checksum validation for newly downloaded deployment images. Previously, the check would always fail, even if the checksum matched.

Closes-Bug: #2115188
Change-Id: I8ddfad37ec97c13bd6d37cd4d62d5b3bc089b9ac